### PR TITLE
Fixes composition of mails with attachments

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,9 @@
 Changelog
 ---------
+
+- Fixes composition of mails with attachments.
+  [msom]
+
 0.54.2 (2017-12-11)
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The emails have currently the following structure:

- mime-multipart/alternative
  - text/plain
  - text/html

Adding attachments simply adds them to the `mime-multipart/alternative`:

- mime-multipart/alternative
  - text/plain
  - text/html
  - application/xxx
  - ...

I think the correct structure would be:
- multipart/mixed
  - mime-multipart/alternative
    - text/plain
    - text/html
  - application/xxx
  - ...
