### PR TITLE
Fixes the default locale negotiator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,9 @@
 Changelog
 ---------
 
+- Fixes the default locale negotiator.
+  [msom]
+
 - Fixes a rare race-condition with request messages.
   [href]
 

--- a/onegov/core/framework.py
+++ b/onegov/core/framework.py
@@ -897,6 +897,15 @@ class Framework(
 
         return set(self.translations.keys())
 
+    @cached_property
+    def default_locale(self):
+        """ Returns the default locale. """
+        try:
+            if self.settings.i18n.default_locale:
+                return self.settings.i18n.default_locale
+        except AttributeError:
+            pass
+
     @property
     def identity_secret(self):
         """ The identity secret, guaranteed to only be valid for the current

--- a/onegov/core/i18n.py
+++ b/onegov/core/i18n.py
@@ -102,7 +102,8 @@ def default_locale_negotiator(locales, request):
     if user_locale in locales:
         return user_locale
 
-    if bool(request.accept_language):
+    # we need to check if there is a valid header before matching it
+    if request.accept_language:
         return request.accept_language.best_match(locales)
 
     return None

--- a/onegov/core/i18n.py
+++ b/onegov/core/i18n.py
@@ -102,7 +102,10 @@ def default_locale_negotiator(locales, request):
     if user_locale in locales:
         return user_locale
 
-    return request.accept_language.best_match(locales)
+    if bool(request.accept_language):
+        return request.accept_language.best_match(locales)
+
+    return None
 
 
 def pofiles(localedir):

--- a/onegov/core/request.py
+++ b/onegov/core/request.py
@@ -329,7 +329,7 @@ class CoreRequest(IncludeRequest, ContentSecurityRequest, ReturnToMixin):
 
         locale = settings.i18n.locale_negotiator(self.app.locales, self)
 
-        return locale or settings.i18n.default_locale
+        return locale or self.app.default_locale
 
     @cached_property
     def html_lang(self):

--- a/onegov/core/request.py
+++ b/onegov/core/request.py
@@ -320,7 +320,7 @@ class CoreRequest(IncludeRequest, ContentSecurityRequest, ReturnToMixin):
     @cached_property
     def default_locale(self):
         """ Returns the default locale. """
-        return self.app.settings.i18n.default_locale
+        return self.app.default_locale
 
     @cached_property
     def locale(self):

--- a/onegov/core/tests/test_framework.py
+++ b/onegov/core/tests/test_framework.py
@@ -487,6 +487,7 @@ def test_get_localized_form():
 
     class App(Framework):
         locales = {}
+        default_locale = None
 
     @App.path(path='/')
     class Root(object):
@@ -513,6 +514,9 @@ def test_get_localized_form():
     assert client.get('/form').text == 'This field is required.'
 
     App.locales = {'de'}
+    assert client.get('/form').text == 'This field is required.'
+
+    App.default_locale = 'de'
     assert client.get('/form').text == 'Dieses Feld wird benötigt.'
 
 


### PR DESCRIPTION
`default_locale_negotiator` does not return None, if no match can be found.  `AcceptLanguageNoHeader.best_match(locales)` basically returns the first of the given locales. Since `locales` is a set in our case, this is more or less random.

The pull request changes the behaviour to match the description and adds the default locale (similar to the locales) as cached property to to app for convenience.