### PR TITLE
Multiple associations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,9 @@
 Changelog
 ---------
+
+- Allows multiple associations per model.
+  [msom]
+
 0.73.1 (2018-10-11)
 ~~~~~~~~~~~~~~~~~~~
 
@@ -10,12 +14,12 @@ Changelog
 ~~~~~~~~~~~~~~~~~~~
 
 - Moves the yubikey related functions to the core (from onegov.user).
-  
+
   In the future, it might make sense to move this to a onegov.otp package. In
   any case, onegov.user is not the right place as the integraiton happens in
   onegov.core as it is and the user model should not be a prerequisite for
   yubikeys.
-  
+
   [href]
 
 0.72.5 (2018-10-04)

--- a/onegov/core/orm/abstract/associable.py
+++ b/onegov/core/orm/abstract/associable.py
@@ -130,7 +130,11 @@ def associated(associated_cls, attribute_name, cardinality='one-to-many',
         uselist = not cardinality.endswith('to-one')
 
     def descriptor(cls):
-        name = '_for_'.join((associated_cls.__tablename__, cls.__tablename__))
+        name = '{}_for_{}_{}'.format(
+            associated_cls.__tablename__,
+            cls.__tablename__,
+            attribute_name
+        )
         key = '{}_id'.format(cls.__tablename__)
         target = '{}.id'.format(cls.__tablename__)
         backref = 'linked_{}'.format(cls.__tablename__)

--- a/onegov/core/upgrades.py
+++ b/onegov/core/upgrades.py
@@ -90,7 +90,7 @@ def migrate_to_jsonb(connection, schemas):
             yield True
 
 
-@upgrade_task('Rename associated tables', always_run=True)
+@upgrade_task('Rename associated tables')
 def rename_associated_tables(context):
     bases = set()
 

--- a/onegov/core/upgrades.py
+++ b/onegov/core/upgrades.py
@@ -105,7 +105,15 @@ def rename_associated_tables(context):
                 continue
 
             if context.has_table(old_name) and context.has_table(new_name):
-                # the new table has probably already been made by the ORM
+                # We expect that the ORM already created the new tables at this
+                # point while still having the old one - we therefore drop the
+                # newly created table (which should be empty at this time).
+                sql = f'SELECT count(*) FROM {new_name}'
+                assert context.session.execute(sql).fetchone().count == 0, f"""
+                    Can not rename the associated table "{old_name}" to
+                    "{new_name}", the new table "{new_name}" already exists
+                    and contains values.
+                """
                 context.operations.drop_table(new_name)
 
             if context.has_table(old_name) and not context.has_table(new_name):


### PR DESCRIPTION
Using a naming scheme for associated files which includes the attribute name allows to define multiple associations per model, e.g.:

```python
class MyFirstFile(File):
    __mapper_args__ = {'polymorphic_identity': 'first'}


class MySecondFile(File):
    __mapper_args__ = {'polymorphic_identity': 'second'}


class MyModel(Base):
    first = associated(MyFirstFile, 'first')
    second = associated(MySecondFile, 'second')
```