### PR TITLE
Moves the elements to the core (from onegov.org)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,9 @@
 Changelog
 ---------
+
+- Moves the elements to the core (from onegov.org).
+  [msom]
+
 0.76.0 (2019-01-23)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/onegov/core/elements.py
+++ b/onegov/core/elements.py
@@ -1,0 +1,240 @@
+""" Elements are mini chameleon macros, usually used to render a single
+element. Sometimes it is useful to not just apply a macro, but to have an
+actual object representing that code snippet. The prime example being links.
+
+Elements are rendered in chameleon templates by calling them with the layout
+object::
+
+    <tal:b replace="structure element(layout)" />
+
+Note that no matter how quick the elements rendering is, using chameleon
+templates directly is faster.
+
+This module should eventually replace the elements.py module.
+
+"""
+
+from onegov.core.templates import render_macro
+
+
+class Element(object):
+    """ Provides a way to define elements trough multiple variables. These
+    elements may then be rendered by the elements.pt templates.
+
+    Elements are simple, they render whatever text and attributes the get.
+    They also carry a dictionary with properties on them, so any kind of
+    value may be attached to an element. For example this works::
+
+        user = object()
+        element = Element(model=user)
+        assert element.user == user
+
+    Since we might use a complex set of attributes which need to be set in
+    a certain way we use a traits system to avoid having to rely too heavily
+    on class inheritance.
+
+    Basically traits are callables called with attributes which they may
+    manipulate. For example, a trait might turn a simple argument into
+    a set of attributes::
+
+        Element(traits=[Editor(buttons=['new', 'edit', 'delete'])])
+
+    See the link traits further down to see examples.
+
+    """
+
+    # The link refers to the id of the macro written in elements.pt
+    id = None
+
+    __slots__ = ('text', 'attrs', 'props')
+
+    def __init__(self, text=None, attrs=None, traits=(), **props):
+        self.text = text
+        self.props = props
+        self.attrs = self.normalize_attrs(attrs)
+
+        if isinstance(traits, Trait):
+            traits = (traits, )
+
+        for trait in traits:
+            self.attrs = trait(self.attrs, **props)
+
+    def normalize_attrs(self, attrs):
+        """ Before we do anything with attributes we make sure we can easily
+        add/remove classes from them, so we use a set.
+
+        """
+        attrs = attrs or {}
+
+        if 'class' not in attrs:
+            attrs['class'] = set()
+        elif isinstance(attrs['class'], str):
+            attrs['class'] = set(attrs['class'].split(' '))
+        else:
+            attrs['class'] = set(attrs['class'])
+
+        return attrs
+
+    def __eq__(self, other):
+        return self.id == other.id\
+            and self.attrs == other.attrs\
+            and self.props == other.props
+
+    def __getattr__(self, name):
+        if name in self.props:
+            return self.props[name]
+
+        raise AttributeError(name)
+
+    def __call__(self, layout, extra_classes=None):
+        if extra_classes:
+            self.attrs['class'].update(extra_classes)
+
+        if self.attrs['class']:
+            if not isinstance(self.attrs['class'], str):
+                self.attrs['class'] = ' '.join(self.attrs['class'])
+        else:
+            del self.attrs['class']
+
+        return render_macro(layout.elements[self.id], layout.request, {
+            'e': self, 'layout': layout,
+        })
+
+
+class HiddenLinkMixin(object):
+    """ Hidden links point to views which are not available to the public
+    (usually through a publication mechanism).
+
+    We mark those links with an icon. This mixin automatically does that
+    for links which bear a model property.
+
+    """
+
+    __slots__ = ()
+
+    @property
+    def is_hidden_from_public(self):
+        """ Returns True if Link is hidden from the public. Pass extra keyword
+        ``model`` to ``__init__`` to have this work automatically.
+
+        """
+        if hasattr(self, 'model'):
+            return getattr(self.model, 'is_hidden_from_public', False)
+
+        return False
+
+
+class Link(Element, HiddenLinkMixin):
+    """ A generic link. """
+
+    id = 'link'
+
+    __slots__ = ()
+
+    def __init__(self, text, url='#', attrs=None, traits=(), **props):
+        # this is the only exception we permit where we don't use a trait
+        # to change the attributes - we do this because the url is essential
+        # to a link, so it makes sense to have it as a proper argument
+        attrs = attrs or {}
+        attrs['href'] = url
+
+        super().__init__(text, attrs, traits, **props)
+
+
+class LinkGroup(HiddenLinkMixin):
+    """ Represents a list of links. """
+
+    __slots__ = [
+        'title',
+        'links',
+        'model',
+        'right_side',
+        'classes',
+        'attributes'
+    ]
+
+    def __init__(self, title, links,
+                 model=None, right_side=True, classes=None, attributes=None):
+        self.title = title
+        self.links = links
+        self.model = model
+        self.right_side = right_side
+        self.classes = classes
+        self.attributes = attributes
+
+
+class Trait(object):
+    """ Base class for all traits. """
+
+    __slots__ = ('apply', )
+
+    def __call__(self, attrs, **ignored):
+        return self.apply(attrs)
+
+
+class Confirm(Trait):
+    """ Links with a confirm link will only be triggered after a question has
+    been answered with a yes::
+
+        link = Link(_("Continue"), '/last-step', traits=(
+            Confirm(
+                _("Do you really want to continue?"),
+                _("This cannot be undone"),
+                _("Yes"), _("No")
+            ),
+        ))
+
+    """
+
+    __slots__ = ()
+
+    def __init__(self, confirm, extra=None, yes="Yes", no="Cancel",
+                 **ignored):
+        def apply(attrs):
+            attrs['class'].add('confirm')
+            attrs['data-confirm'] = confirm
+            attrs['data-confirm-extra'] = extra
+            attrs['data-confirm-yes'] = yes
+            attrs['data-confirm-no'] = no
+            return attrs
+
+        self.apply = apply
+
+
+class Block(Confirm):
+    """ A block trait is a confirm variation with no way to say yes. """
+
+    __slots__ = ()
+
+    def __init__(self, message, extra=None, no="Cancel", **ignored):
+        super().__init__(message, extra, None, no)
+
+
+class Intercooler(Trait):
+    """ Turns the link into an intercooler request. As a result, the link
+    will be exeucted as an ajax request.
+
+    See http://intercoolerjs.org.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, request_method, target=None, redirect_after=None,
+                 **ignored):
+        def apply(attrs):
+            if request_method == 'GET':
+                attrs['ic-get-from'] = attrs['href']
+            elif request_method == 'POST':
+                attrs['ic-post-to'] = attrs['href']
+            elif request_method == 'DELETE':
+                attrs['ic-delete-from'] = attrs['href']
+
+            del attrs['href']
+            attrs['ic-target'] = target
+
+            if redirect_after:
+                attrs['redirect-after'] = redirect_after
+
+            return attrs
+
+        self.apply = apply

--- a/onegov/core/layout.py
+++ b/onegov/core/layout.py
@@ -6,6 +6,7 @@ import numbers
 import sedate
 
 from cached_property import cached_property
+from chameleon import PageTemplate
 from datetime import datetime
 from functools import lru_cache
 from onegov.core import utils
@@ -215,5 +216,24 @@ class ChameleonLayout(Layout):
         See ``templates/macros.pt``.
 
         """
-
         return self.template_loader.macros
+
+    @cached_property
+    def elements(self):
+        """ The templates used by the elements. Overwrite this with your
+        own ``templates/elements.pt`` if neccessary.
+
+        """
+        try:
+            return self.template_loader['elements.pt']
+        except ValueError:
+            return PageTemplate(
+                """<xml xmlns="http://www.w3.org/1999/xhtml">
+                    <metal:b define-macro="link">
+                        <a tal:attributes="e.attrs">${e.text or ''}</a>
+                    </metal:b>
+                    <metal:b define-macro="img">
+                        <img tal:attributes="e.attrs" />
+                    </metal:b>
+                </xml>"""
+            )

--- a/onegov/core/tests/test_elements.py
+++ b/onegov/core/tests/test_elements.py
@@ -1,0 +1,74 @@
+from onegov.core.utils import Bunch
+from onegov.core.elements import Link, Confirm, Intercooler
+
+
+def test_link(render_element):
+    # text is translated
+    result = render_element(Link(text="Settings", url='/settings'))
+    assert result.pyquery('a').text() == "Settings"
+    assert result.pyquery('a').attr('href') == '/settings'
+
+    # other attributes are rendered
+    result = render_element(Link(text='foo', url='#', attrs={
+        'data-foo': 'bar'
+    }))
+    assert result.pyquery('a').attr('data-foo') == 'bar'
+
+    # we show a hint if the link is hidden from public
+    result = render_element(Link(text='hidden', url='#', model=Bunch(
+        is_hidden_from_public=True
+    )))
+
+
+def test_confirm_link(render_element):
+    result = render_element(Link(text="Delete", url='#', traits=(
+        Confirm(
+            "Confirm?",
+            "Extra...",
+            "Yes",
+            "No"
+        ),
+    ), attrs={'class': 'foo'}))
+
+    assert result.pyquery('a').attr('data-confirm') == "Confirm?"
+    assert result.pyquery('a').attr('data-confirm-extra') == "Extra..."
+    assert result.pyquery('a').attr('data-confirm-yes') == "Yes"
+    assert result.pyquery('a').attr('data-confirm-no') == "No"
+    assert result.pyquery('a').attr('class') in ('foo confirm', 'confirm foo')
+
+
+def test_link_slots():
+    # make sure that the Link class as well as all its parents have
+    # __slots__ defined (for some lookup speed and memory improvements)
+    assert not hasattr(Link("Slots", '#'), '__dict__')
+
+
+def test_intercooler_link(render_element):
+    result = render_element(Link(text="Delete", traits=Intercooler(
+        request_method="POST", redirect_after='#redirect', target='#target'
+    )))
+
+    assert result.pyquery('a').attr('ic-post-to') == '#'
+    assert result.pyquery('a').attr('ic-target') == '#target'
+    assert result.pyquery('a').attr('redirect-after') == '#redirect'
+    assert result.pyquery('a').attr('href') is None
+
+
+def test_class_attributes(render_element):
+    result = render_element(Link(text="Delete", attrs={
+        'class': 'foo'
+    }))
+    assert result.pyquery('a').attr('class') == 'foo'
+
+    result = render_element(Link(text="Delete", attrs={
+        'class': ('foo', 'bar')
+    }))
+    assert result.pyquery('a').attr('class') in ('foo bar', 'bar foo')
+
+    result = render_element(Link(text="Delete", attrs={
+        'class': ('foo', 'bar')
+    }))
+    assert result.pyquery('a').attr('class') in ('foo bar', 'bar foo')
+
+    result = render_element(Link(text="Delete"))
+    assert result.pyquery('a').attr('class') is None

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
             'freezegun',
             'onegov_testing',
             'openpyxl',
+            'pyquery',
             'pytest-localserver',
             'pytest-rerunfailures',
             'requests'


### PR DESCRIPTION
Caveats:
- A custom `elements.pt` is used if found, else a fallback is provided. The fallback does not contain the hidden element hint (its a macro and translated).
- The default texts of the Confirm and Block elements are not translated anymore (the changes below include setting the parameters accordingly).

The changes needed in the other packages are:
- https://github.com/OneGov/onegov.agency/tree/elements
- https://github.com/OneGov/onegov.feriennet/tree/elements
- https://github.com/OneGov/onegov.org/tree/elements
- https://github.com/OneGov/onegov.winterthur/tree/elements